### PR TITLE
Add padding to line graphs to support large numbers on y axis, fix ending time

### DIFF
--- a/src/Dashboard/cells/countdown.jsx
+++ b/src/Dashboard/cells/countdown.jsx
@@ -147,7 +147,7 @@ class CountDown extends React.Component {
 
   initializeState() {
     getTimes().then(data => {
-      const { eventStart: startTime, eventEnd: endTime } = data;
+      const { eventStart: startTime, hackEnd: endTime } = data;
 
       const currentTime = Math.floor(Date.now() / 1000);
       let difference = startTime - currentTime;

--- a/src/Dashboard/cells/stats.jsx
+++ b/src/Dashboard/cells/stats.jsx
@@ -150,7 +150,7 @@ export default class Stats extends React.Component {
         animate={{ duration: 2000, easing: 'quadInOut' }}
         theme={VictoryTheme.grayscale}
         padding={{
-          left: 50,
+          left: 70,
           top: 40,
           right: 50,
           bottom: 95,


### PR DESCRIPTION
Adds some padidng to the line graph b/c total lines of code is in the six digits and is overflowing. This supports up to seven (9m lines). Also uses the "hacking end" time in the blobstore instead of event end.